### PR TITLE
After clearing, get new baubles inventory instead of working with old one

### DIFF
--- a/src/main/java/baubles/common/network/PacketSyncBauble.java
+++ b/src/main/java/baubles/common/network/PacketSyncBauble.java
@@ -64,6 +64,7 @@ public class PacketSyncBauble implements IMessage, IMessageHandler<PacketSyncBau
 			if (message.initial) {
 				if (message.slot == 0) {
 					PlayerHandler.clearClientPlayerBaubles();
+					baubles = PlayerHandler.getPlayerBaubles(player);
 				}
 				baubles.stackList[message.slot] = message.bauble;
 				if (message.bauble != null && message.bauble.getItem() instanceof IBauble itemBauble) {


### PR DESCRIPTION
Minor oversight from my last PR.
Otherwise  PlayerHandler.getPlayerBaubles(player) will create a new inventory while we fill the old one

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/21671

Fixes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/21810