### PR TITLE
Hide debug items from NEI

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -1,3 +1,3 @@
 dependencies {
-    implementation("com.github.GTNewHorizons:NotEnoughItems:2.8.0-GTNH:dev")
+    implementation("com.github.GTNewHorizons:NotEnoughItems:2.8.16-GTNH:dev")
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,7 @@ pluginManagement {
 }
 
 plugins {
-    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.43'
+    id 'com.gtnewhorizons.gtnhsettingsconvention' version '1.0.44'
 }
 
 

--- a/src/main/java/baubles/common/Baubles.java
+++ b/src/main/java/baubles/common/Baubles.java
@@ -3,6 +3,8 @@ package baubles.common;
 import java.io.File;
 
 import baubles.Tags;
+import codechicken.nei.api.API;
+import cpw.mods.fml.common.Loader;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -64,6 +66,9 @@ public class Baubles {
         NetworkRegistry.INSTANCE.registerGuiHandler(instance, proxy);
           proxy.registerKeyBindings();
           GameRegistry.registerItem(itemDebugger, "bauble_slot_debug_tool", Baubles.MODID);
+          if (BaublesConfig.hideDebugItem && Loader.isModLoaded("NotEnoughItems")){
+              API.hideItem("bauble_slot_debug_tool");
+          }
     }
 
 }


### PR DESCRIPTION
<img width="1238" height="908" alt="image" src="https://github.com/user-attachments/assets/4a5dd343-a9e1-45ef-86a2-79d08da0bc50" />
They will be shown if debugging is set to true.

This should probably be in 2.8.1, @Dream-Master 