### PR TITLE
Implement multi-column logic

### DIFF
--- a/src/main/java/baubles/client/gui/GuiPlayerExpanded.java
+++ b/src/main/java/baubles/client/gui/GuiPlayerExpanded.java
@@ -146,9 +146,7 @@ public class GuiPlayerExpanded extends GuiContainer implements INEIGuiHandler {
     private void drawBaubleSlots() {
         drawTexturedModalRect(guiLeft, guiTop, 0, 0, xSize, ySize);
         int columns = getColumns();
-        int activeSlots = BaubleExpandedSlots.slotsCurrentlyUsed();
-        int rows = (activeSlots + columns - 1) / columns;
-        int upperHeight = 7 + rows * 18;
+        int upperHeight = 7 + ((BaubleExpandedSlots.slotsCurrentlyUsed() + columns - 1) / columns) * 18;
         if (!useOldGuiRendering) {
             this.mc.getTextureManager().bindTexture(gui_background);
         }
@@ -193,8 +191,7 @@ public class GuiPlayerExpanded extends GuiContainer implements INEIGuiHandler {
             } else {
                 // Draw the background rect at the slot's actual display position so it
                 // automatically follows scrolling and stays in sync with the item rendering.
-                ContainerPlayerExpanded container = (ContainerPlayerExpanded) inventorySlots;
-                SlotBauble baubleSlot = container.getBaubleSlot(slotIndex);
+                SlotBauble baubleSlot = ((ContainerPlayerExpanded) inventorySlots).getBaubleSlot(slotIndex);
                 if (baubleSlot == null || baubleSlot.yDisplayPosition == -2000) {
                     continue;
                 }
@@ -461,11 +458,7 @@ public class GuiPlayerExpanded extends GuiContainer implements INEIGuiHandler {
         }
 
         if (needsScrollBars()) {
-            int scrollPanelXStart = this.guiLeft - 26 - columns * 18;
-            int scrollPanelXEnd   = this.guiLeft - 8 - columns * 18;
-            if (mouseX >= scrollPanelXStart && mouseX < scrollPanelXEnd) {
-                return true;
-            }
+            return mouseX >= this.guiLeft - 26 - columns * 18 && mouseX < this.guiLeft - 8 - columns * 18;
         }
 
         return false;

--- a/src/main/java/baubles/client/gui/GuiPlayerExpanded.java
+++ b/src/main/java/baubles/client/gui/GuiPlayerExpanded.java
@@ -2,6 +2,7 @@ package baubles.client.gui;
 
 import baubles.api.IBauble;
 import baubles.api.expanded.IBaubleExpanded;
+import baubles.common.container.SlotBauble;
 import codechicken.lib.vec.Rectangle4i;
 import codechicken.nei.NEIClientConfig;
 import codechicken.nei.VisiblityData;
@@ -157,14 +158,19 @@ public class GuiPlayerExpanded extends GuiContainer implements INEIGuiHandler {
             slotStartX = guiLeft + 79;
             slotStartY = guiTop + 7;
         } else {
-            if (BaubleExpandedSlots.slotsCurrentlyUsed() <= 8) {
-                this.drawTexturedModalRect(this.guiLeft - 26, this.guiTop + 4, 0, 0, 27, upperHeight);
-                this.drawTexturedModalRect(this.guiLeft - 26, this.guiTop + 4 + upperHeight, 0, 151, 27, 7);
-            } else {
-                this.drawTexturedModalRect(this.guiLeft - 26, this.guiTop + 4, 0, 0, 27, 158);
-                this.drawTexturedModalRect(this.guiLeft - 42, this.guiTop + 4, 27, 0, 23, 158);
+            int columns = getColumns();
+
+            // First column is drawn separately because it has 2 extra pixels of padding
+            this.drawTexturedModalRect(this.guiLeft - 26, this.guiTop + 4, 0, 0, 27, 158);
+            for (int col = 1; col < columns; col++) {
+                this.drawTexturedModalRect(this.guiLeft - 26 - col * 18, this.guiTop + 4, 0, 0, 25, 158);
+            }
+            if (needsScrollBars()) {
+                // Scrollbar panel sits immediately left of the leftmost slot column
+                int scrollPanelX = this.guiLeft - 26 - columns * 18;
+                this.drawTexturedModalRect(scrollPanelX, this.guiTop + 4, 27, 0, 23, 158);
                 this.mc.getTextureManager().bindTexture(creative_inventory_tabs);
-                this.drawTexturedModalRect(this.guiLeft - 34, this.guiTop + 12 + (int) (127f * this.currentScroll), 232, 0, 12, 15);
+                this.drawTexturedModalRect(scrollPanelX + 8, this.guiTop + 12 + (int) (127f * this.currentScroll), 232, 0, 12, 15);
             }
         }
 
@@ -177,15 +183,23 @@ public class GuiPlayerExpanded extends GuiContainer implements INEIGuiHandler {
             if (useOldGuiRendering) {
                 drawTexturedModalRect(slotStartX + (slotOffset * (slotIndex / 4)), slotStartY + (slotOffset * (slotIndex % 4)), 200, 0, 18, 18);
             } else {
-                drawTexturedModalRect(slotStartX + (slotOffset * (slotIndex / 4)), slotStartY + (slotOffset * slotIndex), 200, 0, 18, 18);
+                // Draw the background rect at the slot's actual display position so it
+                // automatically follows scrolling and stays in sync with the item rendering.
+                ContainerPlayerExpanded container = (ContainerPlayerExpanded) inventorySlots;
+                SlotBauble baubleSlot = container.getBaubleSlot(slotIndex);
+                if (baubleSlot == null || baubleSlot.yDisplayPosition == -2000) {
+                    continue;
+                }
+                drawTexturedModalRect(guiLeft + baubleSlot.xDisplayPosition, guiTop + baubleSlot.yDisplayPosition, 200, 0, 18, 18);
             }
         }
     }
 
     private void drawPotionEffects() {
-        int slotIndent = 26;
-        if (BaubleExpandedSlots.slotsCurrentlyUsed() > 8) {
-            slotIndent = 42;
+        int columns = getColumns();
+        int slotIndent = 26 + (columns - 1) * 18;
+        if (needsScrollBars()) {
+            slotIndent += 16;
         }
         int positionHorizontal = guiLeft - slotIndent - 124;
         int positionVertical = guiTop;
@@ -305,6 +319,14 @@ public class GuiPlayerExpanded extends GuiContainer implements INEIGuiHandler {
         return ((ContainerPlayerExpanded) this.inventorySlots).canScroll();
     }
 
+    /**
+     * Returns the number of slot columns to display, between 1 and maxColumns.
+     * Delegates to the container so both sides agree on the layout.
+     */
+    private int getColumns() {
+        return ((ContainerPlayerExpanded) this.inventorySlots).getColumns();
+    }
+
     private void handleScrollbar(int mouseX, int mouseY) {
         boolean leftMouseDown = Mouse.isButtonDown(0);
 
@@ -403,11 +425,16 @@ public class GuiPlayerExpanded extends GuiContainer implements INEIGuiHandler {
         super.mouseMovedOrUp(mouseX, mouseY, mouseButton);
     }
 
+    private int getScrollbarX() {
+        int columns = getColumns();
+        return this.guiLeft - 26 - columns * 18 + 8;
+    }
+
     /**
      * Returns true if the mouse is clicked in the scroll bar.
      */
     private boolean isClickInScrollbar(int mouseX, int mouseY) {
-        int scrollbarXStart = this.guiLeft - 34;
+        int scrollbarXStart = getScrollbarX();
         int scrollbarYStart = this.guiTop + 12;
         int scrollbarXEnd = scrollbarXStart + 14;
         int scrollbarYEnd = scrollbarYStart + 139;
@@ -416,17 +443,28 @@ public class GuiPlayerExpanded extends GuiContainer implements INEIGuiHandler {
             mouseX < scrollbarXEnd && mouseY < scrollbarYEnd;
     }
 
-    /**
-     * Returns true if the mouse is clicked in the scrollbar or the surrounding area.
-     */
     private boolean isClickInUI(int mouseX, int mouseY) {
-        int scrollbarXStart = this.guiLeft - 42;
-        int scrollbarYStart = this.guiTop + 5;
-        int scrollbarXEnd = scrollbarXStart + 27;
-        int scrollbarYEnd = scrollbarYStart + 156;
+        int columns = getColumns();
+        int uiYStart = this.guiTop + 4;
+        int uiYEnd   = uiYStart + 158;
 
-        return mouseX >= scrollbarXStart && mouseY >= scrollbarYStart &&
-            mouseX < scrollbarXEnd && mouseY < scrollbarYEnd;
+        if (mouseY < uiYStart || mouseY >= uiYEnd) {
+            return false;
+        }
+
+        if (mouseX >= this.guiLeft - 8 && mouseX < this.guiLeft) {
+            return true;
+        }
+
+        if (needsScrollBars()) {
+            int scrollPanelXStart = this.guiLeft - 26 - columns * 18;
+            int scrollPanelXEnd   = this.guiLeft - 8 - columns * 18;
+            if (mouseX >= scrollPanelXStart && mouseX < scrollPanelXEnd) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     @Override
@@ -456,21 +494,27 @@ public class GuiPlayerExpanded extends GuiContainer implements INEIGuiHandler {
     @Override
     @Optional.Method(modid = "NotEnoughItems")
     public boolean hideItemPanelSlot(GuiContainer gui, int slotX, int slotY, int slotW, int slotH) {
-        int upperHeight = 7 + BaubleExpandedSlots.slotsCurrentlyUsed() * 18;
         if (!(gui instanceof GuiPlayerExpanded) || useOldGuiRendering) {
             return false;
         }
-        int slotIndent = 26;
-        int slotWidth = 18;
-        if (BaubleExpandedSlots.slotsCurrentlyUsed() > 8) {
-            slotIndent = 42;
-            slotWidth = 36;
+
+        int columns = getColumns();
+        int slotPanelWidth = 8 + columns * 18;
+        int slotIndent = 8 + columns * 18;
+        int totalWidth = slotPanelWidth;
+        if (needsScrollBars()) {
+            totalWidth += 16;
+            slotIndent += 16;
         }
+
+        int upperHeight = 7 + BaubleExpandedSlots.slotsCurrentlyUsed() * 18;
+
+        Rectangle4i baubleSlots = new Rectangle4i(guiLeft - slotIndent, guiTop + 4, totalWidth, upperHeight + 4);
+
         if (NEIClientConfig.ignorePotionOverlap()) {
-            return (new Rectangle4i( guiLeft - slotIndent, guiTop + 4, slotWidth, upperHeight + 4).intersects(new Rectangle4i(slotX, slotY, slotW, slotH)));
+            return baubleSlots.intersects(new Rectangle4i(slotX, slotY, slotW, slotH));
         }
-        int x = this.guiLeft - 124 - slotIndent;
-        int y = this.guiTop;
+
         Minecraft minecraft = gui.mc;
         if (minecraft == null) {
             return false;
@@ -481,14 +525,17 @@ public class GuiPlayerExpanded extends GuiContainer implements INEIGuiHandler {
         }
         Collection<PotionEffect> activePotionEffects = player.getActivePotionEffects();
         if (activePotionEffects.isEmpty()) {
-            return (new Rectangle4i( guiLeft - slotIndent, guiTop + 4, slotWidth, upperHeight + 4).intersects(new Rectangle4i(slotX, slotY, slotW, slotH)));
+            return baubleSlots.intersects(new Rectangle4i(slotX, slotY, slotW, slotH));
         }
+
         int height = 33;
         if (activePotionEffects.size() > 5) {
             height = 132 / (activePotionEffects.size() - 1);
         }
+
+        int x = this.guiLeft - 124 - slotIndent;
+        int y = this.guiTop;
         Rectangle4i slotRect = new Rectangle4i(slotX, slotY, slotW, slotH);
-        Rectangle4i baubleSlots = new Rectangle4i( guiLeft - slotIndent, guiTop + 4, slotWidth, upperHeight + 4);
         for (PotionEffect effect : activePotionEffects) {
             Rectangle4i box = new Rectangle4i(x, y, 140, 32);
             box.include(baubleSlots);

--- a/src/main/java/baubles/client/gui/GuiPlayerExpanded.java
+++ b/src/main/java/baubles/client/gui/GuiPlayerExpanded.java
@@ -504,7 +504,7 @@ public class GuiPlayerExpanded extends GuiContainer implements INEIGuiHandler {
             slotIndent += 16;
         }
 
-        int upperHeight = 7 + BaubleExpandedSlots.slotsCurrentlyUsed() * 18;
+        int upperHeight = 7 + ((BaubleExpandedSlots.slotsCurrentlyUsed() + columns - 1) / columns) * 18;
 
         Rectangle4i baubleSlots = new Rectangle4i(guiLeft - slotIndent, guiTop + 4, totalWidth, upperHeight + 4);
 

--- a/src/main/java/baubles/client/gui/GuiPlayerExpanded.java
+++ b/src/main/java/baubles/client/gui/GuiPlayerExpanded.java
@@ -145,7 +145,10 @@ public class GuiPlayerExpanded extends GuiContainer implements INEIGuiHandler {
 
     private void drawBaubleSlots() {
         drawTexturedModalRect(guiLeft, guiTop, 0, 0, xSize, ySize);
-        int upperHeight = 7 + BaubleExpandedSlots.slotsCurrentlyUsed() * 18;
+        int columns = getColumns();
+        int activeSlots = BaubleExpandedSlots.slotsCurrentlyUsed();
+        int rows = (activeSlots + columns - 1) / columns;
+        int upperHeight = 7 + rows * 18;
         if (!useOldGuiRendering) {
             this.mc.getTextureManager().bindTexture(gui_background);
         }
@@ -158,19 +161,24 @@ public class GuiPlayerExpanded extends GuiContainer implements INEIGuiHandler {
             slotStartX = guiLeft + 79;
             slotStartY = guiTop + 7;
         } else {
-            int columns = getColumns();
-
-            // First column is drawn separately because it has 2 extra pixels of padding
-            this.drawTexturedModalRect(this.guiLeft - 26, this.guiTop + 4, 0, 0, 27, 158);
-            for (int col = 1; col < columns; col++) {
-                this.drawTexturedModalRect(this.guiLeft - 26 - col * 18, this.guiTop + 4, 0, 0, 25, 158);
-            }
             if (needsScrollBars()) {
-                // Scrollbar panel sits immediately left of the leftmost slot column
+                // If scrollbar is active draw columns at full size always
+                this.drawTexturedModalRect(this.guiLeft - 26, this.guiTop + 4, 0, 0, 27, 158);
+                for (int col = 1; col < columns; col++) {
+                    this.drawTexturedModalRect(this.guiLeft - 26 - col * 18, this.guiTop + 4, 0, 0, 25, 158);
+                }
                 int scrollPanelX = this.guiLeft - 26 - columns * 18;
                 this.drawTexturedModalRect(scrollPanelX, this.guiTop + 4, 27, 0, 23, 158);
                 this.mc.getTextureManager().bindTexture(creative_inventory_tabs);
                 this.drawTexturedModalRect(scrollPanelX + 8, this.guiTop + 12 + (int) (127f * this.currentScroll), 232, 0, 12, 15);
+            } else {
+                // Special case for <8 slots to not draw full column
+                this.drawTexturedModalRect(this.guiLeft - 26, this.guiTop + 4, 0, 0, 27, upperHeight);
+                this.drawTexturedModalRect(this.guiLeft - 26, this.guiTop + 4 + upperHeight, 0, 151, 27, 7);
+                for (int col = 1; col < columns; col++) {
+                    this.drawTexturedModalRect(this.guiLeft - 26 - col * 18, this.guiTop + 4, 0, 0, 25, upperHeight);
+                    this.drawTexturedModalRect(this.guiLeft - 26 - col * 18, this.guiTop + 4 + upperHeight, 0, 151, 25, 7);
+                }
             }
         }
 
@@ -319,10 +327,6 @@ public class GuiPlayerExpanded extends GuiContainer implements INEIGuiHandler {
         return ((ContainerPlayerExpanded) this.inventorySlots).canScroll();
     }
 
-    /**
-     * Returns the number of slot columns to display, between 1 and maxColumns.
-     * Delegates to the container so both sides agree on the layout.
-     */
     private int getColumns() {
         return ((ContainerPlayerExpanded) this.inventorySlots).getColumns();
     }

--- a/src/main/java/baubles/common/BaublesConfig.java
+++ b/src/main/java/baubles/common/BaublesConfig.java
@@ -10,6 +10,7 @@ public class BaublesConfig {
 	public static boolean hideDebugItem = true;
 
     public static int[] soulBoundEnchantments = new int[] {};
+    public static int maxColumns = 4;
 
     public static boolean useOldGuiButton = false;
     public static boolean useOldGuiRendering = false;
@@ -46,6 +47,8 @@ public class BaublesConfig {
         //categoryClient
         useOldGuiButton = config.getBoolean("useOldGuiButton", categoryClient, useOldGuiButton, "Use the old Baubles Button texture and location instead.\n");
         useOldGuiRendering = config.getBoolean("useOldRendering", categoryClient, useOldGuiRendering, "Display the old Bauble GUI instead of the new sidebar.\n");
+        maxColumns = config.getInt("maxColumns", categoryClient, 4, 1, 5, "Maximum number of columns shown in the baubles inventory (1-5).\n"
+        );
 
         //categoryMenu
         showUnusedSlots = config.getBoolean("showUnusedSlots", categoryMenu, showUnusedSlots, "Display unused Bauble slots.\n");

--- a/src/main/java/baubles/common/container/ContainerPlayerExpanded.java
+++ b/src/main/java/baubles/common/container/ContainerPlayerExpanded.java
@@ -21,6 +21,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.item.crafting.CraftingManager;
 import net.minecraft.util.IIcon;
 
+import static baubles.common.BaublesConfig.maxColumns;
 import static baubles.common.BaublesConfig.useOldGuiRendering;
 
 public class ContainerPlayerExpanded extends Container {
@@ -87,8 +88,7 @@ public class ContainerPlayerExpanded extends Container {
             if (BaublesConfig.showUnusedSlots || !slotType.equals(BaubleExpandedSlots.unknownType)) {
                 Slot slot = useOldGuiRendering
                     ? new SlotBauble(baubles, slotType, i, slotStartX + (slotOffset * (i / 4)), slotStartY + (slotOffset * (i % 4)))
-                    : new SlotBauble(baubles, slotType, i, -18, 12 + (slotOffset * i));
-
+                    : new SlotBauble(baubles, slotType, i, -18 - (18 * (i % getColumns())), 12 + (slotOffset * (i / getColumns())));
                 addSlotToContainer(slot);
                 baubleSlotCount++;
             }
@@ -160,30 +160,41 @@ public class ContainerPlayerExpanded extends Container {
     public void scrollTo(float offset) {
         if (!canScroll()) return;
         final int activeBaubleSlots = BaubleExpandedSlots.slotsCurrentlyUsed();
+        final int columns = getColumns();
 
         offset = Math.max(0, Math.min(1, offset));
 
-        int shownSlots = 8;
-        int slotOffset = (int) (offset * (activeBaubleSlots - shownSlots) + 0.5F);
+        int shownRows = 8;
+        int totalRows = (activeBaubleSlots + columns - 1) / columns;
+        int slotRowOffset = (int) (offset * (totalRows - shownRows) + 0.5F);
 
-        if (slotOffset < 0) {
-            slotOffset = 0;
+        if (slotRowOffset < 0) {
+            slotRowOffset = 0;
         }
 
         for (int i = 0; i < activeBaubleSlots && i < BaubleExpandedSlots.slotLimit; i++) {
             Slot slot = (Slot) this.inventorySlots.get(baubleFirstSlotIndex + i);
-            if (i >= 0) {
-                slot.yDisplayPosition = (12 - (slotOffset * 18) + (i) * 18);
-                if (slot.yDisplayPosition < 12 || slot.yDisplayPosition > 8 * 18) {
-                    // Hide the rest of the slots!
-                    slot.yDisplayPosition = -2000;
-                }
+            int row = i / columns;
+            int scrolledRow = row - slotRowOffset;
+            slot.yDisplayPosition = 12 + scrolledRow * 18;
+            if (slot.yDisplayPosition < 12 || slot.yDisplayPosition > 8 * 18) {
+                slot.yDisplayPosition = -2000;
             }
         }
     }
 
+    public int getColumns() {
+        int activeBaubleSlots = BaubleExpandedSlots.slotsCurrentlyUsed();
+        for (int cols = 1; cols < maxColumns; cols++) {
+            if ((activeBaubleSlots + cols - 1) / cols <= 8) {
+                return cols;
+            }
+        }
+        return maxColumns;
+    }
+
     public boolean canScroll() {
-        return BaubleExpandedSlots.slotsCurrentlyUsed() > 8 && !useOldGuiRendering;
+        return BaubleExpandedSlots.slotsCurrentlyUsed() > maxColumns * 8 && !useOldGuiRendering;
     }
 
     @Override
@@ -211,24 +222,32 @@ public class ContainerPlayerExpanded extends Container {
         returnStack = originalStack.copy();
         Item item = returnStack.getItem();
 
-        if (!useOldGuiRendering) {
-            if (slotIndex == 0) {
-                if (!mergeItemStack(originalStack, 4 + craftingActive + visibleBaubleSlots, 40 + craftingActive + visibleBaubleSlots, true)) {
-                    return null;
-                }
-                slot.onSlotChange(originalStack, returnStack);
-            } else if (slotIndex < 5) {
-                if (!mergeItemStack(originalStack, 4 + craftingActive + visibleBaubleSlots, 40 + craftingActive + visibleBaubleSlots, false)) {
-                    return null;
-                }
+        final int baubleStart = 4 + craftingActive;
+        final int baubleEnd   = baubleStart + visibleBaubleSlots;
+        final int invEnd      = baubleEnd + 27;
+        final int hotbarEnd   = invEnd + 9;
+
+        if (!useOldGuiRendering && slotIndex == 0) {
+            if (!mergeItemStack(originalStack, baubleEnd, hotbarEnd, true)) {
+                return null;
             }
-        } else if (item instanceof ItemArmor armor && !((Slot) inventorySlots.get(craftingActive + armor.armorType)).getHasStack()) {
+            slot.onSlotChange(originalStack, returnStack);
+        } else if (!useOldGuiRendering && slotIndex < 5) {
+            if (!mergeItemStack(originalStack, baubleEnd, hotbarEnd, false)) {
+                return null;
+            }
+        } else if (slotIndex >= baubleStart && slotIndex < baubleEnd) {
+            if (!mergeItemStack(originalStack, baubleEnd, hotbarEnd, false, slot)) {
+                returnStack = null;
+            }
+        } else if (item instanceof ItemArmor armor
+                && !((Slot) inventorySlots.get(craftingActive + armor.armorType)).getHasStack()) {
             int armorSlot = craftingActive + armor.armorType;
             if (!mergeItemStack(originalStack, armorSlot, armorSlot + 1, false)) {
                 returnStack = null;
             }
-        } else if (slotIndex >= 4 + craftingActive + visibleBaubleSlots && item instanceof IBauble bauble && bauble.canEquip(returnStack, thePlayer)) {
-            for (int baubleSlot = 4 + craftingActive; baubleSlot < 4 + craftingActive + visibleBaubleSlots; baubleSlot++) {
+        } else if (item instanceof IBauble bauble && bauble.canEquip(returnStack, thePlayer)) {
+            for (int baubleSlot = baubleStart; baubleSlot < baubleEnd; baubleSlot++) {
                 if (returnStack == null) {
                     break;
                 }
@@ -243,21 +262,21 @@ public class ContainerPlayerExpanded extends Container {
                 }
                 for (String type : types) {
                     if ((type.equals(BaubleExpandedSlots.universalType)
-                        || type.equals(BaubleExpandedSlots.getSlotType(baubleSlot - 4 - craftingActive)))
+                        || type.equals(BaubleExpandedSlots.getSlotType(baubleSlot - baubleStart)))
                         && !mergeItemStack(originalStack, baubleSlot, baubleSlot + 1, false)) {
                         returnStack = null;
                     }
                 }
             }
-        } else if (slotIndex >= 4 + craftingActive + visibleBaubleSlots && slotIndex < 31 + craftingActive + visibleBaubleSlots) {
-            if (!mergeItemStack(originalStack, 31 + craftingActive + visibleBaubleSlots, 40 + craftingActive + visibleBaubleSlots, false)) {
+        } else if (slotIndex >= baubleEnd && slotIndex < invEnd) {
+            if (!mergeItemStack(originalStack, invEnd, hotbarEnd, false)) {
                 returnStack = null;
             }
-        } else if (slotIndex >= 31 + craftingActive + visibleBaubleSlots && slotIndex < 40 + craftingActive + visibleBaubleSlots) {
-            if (!mergeItemStack(originalStack, 4 + craftingActive + visibleBaubleSlots, 31 + craftingActive + visibleBaubleSlots, false)) {
+        } else if (slotIndex >= invEnd && slotIndex < hotbarEnd) {
+            if (!mergeItemStack(originalStack, baubleEnd, invEnd, false)) {
                 returnStack = null;
             }
-        } else if (!mergeItemStack(originalStack, 4 + craftingActive + visibleBaubleSlots, 40 + craftingActive + visibleBaubleSlots, false, slot)) {
+        } else if (!mergeItemStack(originalStack, baubleEnd, hotbarEnd, false, slot)) {
             returnStack = null;
         }
 


### PR DESCRIPTION
Result of 93% positive poll: https://discord.com/channels/181078474394566657/465207956745486336/1477763793177018368

Baubles inventory now renders as multiple columns instead of a single scrolling column. Columns are dynamically added up to the configurable maxColumns (default 4, chosen because I think it looks fine on AUTO scale). If there are more slots needed than maxColumns * 8, the scrollbar will appear as before, so slots are _still unlimited_.

<img width="850" height="523" alt="image" src="https://github.com/user-attachments/assets/1fb6da0c-f564-4939-a850-008c5609afb9" />

Old behavior can be easily chosen by simply setting maxColumns to 1.

AI Disclosure: My original implementation was about 90% working, but vanilla gui code is super hard to bugfix so I threw it into Claude to locate remaining bugs.