### PR TITLE
Infinite Bauble Slots

### DIFF
--- a/src/main/java/baubles/api/expanded/BaubleExpandedSlots.java
+++ b/src/main/java/baubles/api/expanded/BaubleExpandedSlots.java
@@ -4,357 +4,331 @@ import java.util.ArrayList;
 import java.util.Arrays;
 
 import baubles.api.BaubleType;
-import baubles.common.BaublesConfig;
 import cpw.mods.fml.common.Loader;
 import cpw.mods.fml.common.LoaderState;
 
 public class BaubleExpandedSlots {
 
-	//The total number of slots that can be added.
-	//Please keep in mind that increases to this limit are possible with minimal changes.
-	public static final int slotLimit = 20;
+    //The type used in place of null.
+    public static final String invalidType = "";
 
-	//The type used in place of null.
-	public static final String invalidType = "";
+    //The type used for unassigned slots.
+    public static final String unknownType = "unknown";
 
-	//The type used for unassigned slots.
-	public static final String unknownType = "unknown";
-
-	//Pre-registered types.
-	public static final String ringType = "ring";
-	public static final String amuletType = "amulet";
-	public static final String beltType = "belt";
+    //Pre-registered types.
+    public static final String ringType = "ring";
+    public static final String amuletType = "amulet";
+    public static final String beltType = "belt";
     public static final String universalType = "universal";
-	public static final String headType = "head";
-	public static final String bodyType = "body";
-	public static final String charmType = "charm";
-	public static final String capeType = "cape";
-	public static final String shieldType = "shield";
-	public static final String quiverType = "quiver";
-	public static final String gauntletType = "gauntlet";
-	public static final String earringType = "earring";
-	public static final String wingsType = "wings";
+    public static final String headType = "head";
+    public static final String bodyType = "body";
+    public static final String charmType = "charm";
+    public static final String capeType = "cape";
+    public static final String shieldType = "shield";
+    public static final String quiverType = "quiver";
+    public static final String gauntletType = "gauntlet";
+    public static final String earringType = "earring";
+    public static final String wingsType = "wings";
 
-	/**
-	 * Registers a type and returns true if the type could be or has been registered.
-	 * Types can only be registered while the loader state is pre-initialization.
-	 *
-	 * @param type The type to register.
-	 * @return If a type was registered or had been registered previously.
-	 */
-	public static boolean tryRegisterType(String type) {
-		if(type != null && type.length() > 0) {
-			if(isTypeRegistered(type)) {
-				return true;
-			} else {
-				if(Loader.instance().getLoaderState() == LoaderState.PREINITIALIZATION) {
-					registeredTypes.add(type);
-					return true;
-				}
-			}
-		}
-		return false;
-	}
+    /**
+     * Registers a type and returns true if the type could be or has been registered.
+     * Types can only be registered while the loader state is pre-initialization.
+     *
+     * @param type The type to register.
+     * @return If a type was registered or had been registered previously.
+     */
+    public static boolean tryRegisterType(String type) {
+        if (type == null || type.isEmpty()) {
+            return false;
+        }
+        if (isTypeRegistered(type)) {
+            return true;
+        }
+        if (Loader.instance().getLoaderState() == LoaderState.PREINITIALIZATION) {
+            registeredTypes.add(type);
+            return true;
+        }
+        return false;
+    }
 
-	/**
-	 * Returns false if the type is unregistered or unknown, the minimum number of
-	 * assigned slots cannot be met, or the loader state is not pre-initialization.
-	 *
-	 * @param type The type of the slot to evaluate and possibly assign.
-	 * @param minimumOfType The minimum slots of type to be assigned.
-	 *
-	 * @return If the total assigned slots of the specified type equals or is more than the minimum.
-	 */
-	public static boolean tryAssignSlotsUpToMinimum(String type, int minimumOfType) {
-		if(minimumOfType >= 1 && isTypeRegistered(type) && !type.equals(unknownType) && Loader.instance().getLoaderState() == LoaderState.PREINITIALIZATION) {
-			int total = 0;
-			for(int slotToCheck = 0; slotToCheck < slotLimit; slotToCheck++) {
-				if(assignedSlots[slotToCheck].equals(type)) {
-					total++;
-				}
-			}
-			if(total < minimumOfType) {
-				total = minimumOfType - total;
-				for(int i = 0; i < total; i++) {
-					if(newSlotsRemaining >= 1) {
-						assignedSlots[slotLimit - newSlotsRemaining] = type;
-						newSlotsRemaining--;
-					} else {
-						return false;
-					}
-				}
-			} else {
-				return true;
-			}
-		}
-		return false;
-	}
+    /**
+     * Returns false if the type is unregistered or unknown, the minimum number of
+     * assigned slots cannot be met, or the loader state is not pre-initialization.
+     *
+     * @param type The type of the slot to evaluate and possibly assign.
+     * @param minimumOfType The minimum slots of type to be assigned.
+     *
+     * @return If the total assigned slots of the specified type equals or is more than the minimum.
+     */
+    public static boolean tryAssignSlotsUpToMinimum(String type, int minimumOfType) {
+        if (minimumOfType < 1 || !isTypeRegistered(type) || type.equals(unknownType) || Loader.instance().getLoaderState() != LoaderState.PREINITIALIZATION) {
+            return false;
+        }
+        int total = 0;
+        for (String assignedSlot : assignedSlots) {
+            if (assignedSlot.equals(type)) {
+                total++;
+            }
+        }
+        if (total >= minimumOfType) {
+            return true;
+        }
+        total = minimumOfType - total;
+        for (int i = 0; i < total; i++) {
+            tryAssignSlotOfType(type);
+        }
+        return true;
+    }
 
-	/**
-	 * Returns false if the type is unregistered or unknown, or the
-	 * loader state is not pre-initialization.
-	 *
-	 * @param type The type of the slot to evaluate and possibly unassign.
-	 * @param maximumOfType The maximum slots of type to be left assigned.
-	 *
-	 * @return If the total assigned slots of the specified type equals or is less than the maximum.
-	 */
-	public static boolean tryUnassignSlotsDownToMaximum(String type, int maximumOfType) {
-		if(maximumOfType < 0) maximumOfType = 0;
-		if(isTypeRegistered(type) && !type.equals(unknownType) && Loader.instance().getLoaderState() == LoaderState.PREINITIALIZATION) {
-			int total = 0;
-			for(int slotToCheck = 0; slotToCheck < slotLimit; slotToCheck++) {
-				if(assignedSlots[slotToCheck].equals(type)) {
-					total++;
-				}
-			}
-			if(total > maximumOfType) {
-				total -= maximumOfType;
-				for(int i = 0; i < total; i++) {
-					for(int slotToCheck = slotsCurrentlyUsed(); slotToCheck >= 0; slotToCheck--) {
-						if(assignedSlots[slotToCheck].equals(type)) {
-							for(int slotToMove = slotToCheck + 1; slotToMove < slotLimit; slotToMove++) {
-								assignedSlots[slotToMove - 1] = assignedSlots[slotToMove];
-							}
-							assignedSlots[slotLimit - 1] = unknownType;
-							newSlotsRemaining++;
-							break;
-						}
-					}
-				}
-			}
-			return true;
-		}
-		return false;
-	}
+    /**
+     * Returns false if the type is unregistered or unknown, or the
+     * loader state is not pre-initialization.
+     *
+     * @param type The type of the slot to evaluate and possibly unassign.
+     * @param maximumOfType The maximum slots of type to be left assigned.
+     *
+     * @return If the total assigned slots of the specified type equals or is less than the maximum.
+     */
+    public static boolean tryUnassignSlotsDownToMaximum(String type, int maximumOfType) {
+        if (maximumOfType < 0) maximumOfType = 0;
+        if (!isTypeRegistered(type) || type.equals(unknownType) || Loader.instance().getLoaderState() != LoaderState.PREINITIALIZATION) {
+            return false;
+        }
+        int total = 0;
+        for (String assignedSlot : assignedSlots) {
+            if (assignedSlot.equals(type)) {
+                total++;
+            }
+        }
+        if (total <= maximumOfType) {
+            return true;
+        }
+        total -= maximumOfType;
+        for (int i = 0; i < total; i++) {
+            tryUnassignSlotOfType(type);
+        }
+        return true;
+    }
 
-	/**
-	 * Returns if a slot was assigned successfully.
-	 * Does not assign a type to a slot if the type is unregistered, no slots
-	 * are free, or the loader state is not pre-initialization.
-	 *
-	 * @param type The type to attempt assigning to a slot.
-	 *
-	 * @return If assigning a type to a slot was successful or not.
-	 */
-	public static boolean tryAssignSlotOfType(String type) {
-		if(newSlotsRemaining >= 1 && isTypeRegistered(type) && !type.equals(unknownType) && Loader.instance().getLoaderState() == LoaderState.PREINITIALIZATION) {
-			assignedSlots[slotLimit - newSlotsRemaining] = type;
-			newSlotsRemaining--;
-			return true;
-		} else {
-			return false;
-		}
-	}
+    /**
+     * Returns if a slot was assigned successfully.
+     * Does not assign a type to a slot if the type is unregistered, no slots
+     * are free, or the loader state is not pre-initialization.
+     *
+     * @param type The type to attempt assigning to a slot.
+     *
+     * @return If assigning a type to a slot was successful or not.
+     */
+    public static boolean tryAssignSlotOfType(String type) {
+        if (!isTypeRegistered(type) || type.equals(unknownType) || Loader.instance().getLoaderState() != LoaderState.PREINITIALIZATION) {
+            return false;
+        }
+        assignedSlots.add(type);
+        return true;
+    }
 
-   /**
-	* Unassigns the last slot of the specified type if one can be found
-	* and the loader state is pre-initialization.
-	*
-	* @param type The type of the slot to be unassigned.
-	*
-	* @return If unassigning a slot was successful or not.
-	*/
-	public static boolean tryUnassignSlotOfType(String type) {
-		if(newSlotsRemaining < slotLimit && type != null && !type.equals(unknownType) && Loader.instance().getLoaderState() == LoaderState.PREINITIALIZATION) {
-			for(int slotToCheck = slotsCurrentlyUsed(); slotToCheck >= 0; slotToCheck--) {
-				if(assignedSlots[slotToCheck].equals(type)) {
-					for(int slotToMove = slotToCheck + 1; slotToMove < slotLimit; slotToMove++) {
-						assignedSlots[slotToMove - 1] = assignedSlots[slotToMove];
-					}
-					assignedSlots[slotLimit - 1] = unknownType;
-					newSlotsRemaining++;
-					return true;
-				}
-			}
-		}
-		return false;
-	}
+    /**
+     * Unassigns the last slot of the specified type if one can be found
+     * and the loader state is pre-initialization.
+     *
+     * @param type The type of the slot to be unassigned.
+     *
+     * @return If unassigning a slot was successful or not.
+     */
+    public static boolean tryUnassignSlotOfType(String type) {
+        if (assignedSlots.isEmpty() || type == null || type.equals(unknownType) || Loader.instance().getLoaderState() != LoaderState.PREINITIALIZATION) {
+            return false;
+        }
+        for (int i = assignedSlots.size() - 1; i >= 0; i--) {
+            if (type.equals(assignedSlots.get(i))) {
+                assignedSlots.remove(i);
+                return true;
+            }
+        }
+        return false;
+    }
 
-	/**
-	 * Returns the current number of slots with a matching type.
-	 *
-	 * @param type The type of slot being counted.
-	 *
-	 * @return The current total slots with a matching type assigned.
-	 */
-	public static int totalCurrentlyAssignedSlotsOfType(String type) {
-		int total = 0;
-		if(isTypeRegistered(type)) {
-			for(int slotToCheck = 0; slotToCheck < slotLimit; slotToCheck++) {
-				if(assignedSlots[slotToCheck].equals(type)) {
-					total++;
-				}
-			}
-		}
-		return total;
-	}
+    /**
+     * Returns the current number of slots with a matching type.
+     *
+     * @param type The type of slot being counted.
+     *
+     * @return The current total slots with a matching type assigned.
+     */
+    public static int totalCurrentlyAssignedSlotsOfType(String type) {
+        if (!isTypeRegistered(type)) {
+            return 0;
+        }
+        int total = 0;
+        for (String assignedSlot : assignedSlots) {
+            if (assignedSlot.equals(type)) {
+                total++;
+            }
+        }
+        return total;
+    }
 
-	/**
-	 * Returns an array of slot indexes that have the specified type assigned.
-	 * Do not treat results from this as final until postinit or later.
-	 *
-	 * @param type The type of slot being checked.
-	 *
-	 * @return an array of slot indexes with the specified type.
-	 */
-	public static int[] getIndexesOfAssignedSlotsOfType(String type) {
-		int[] slotIndexes = new int[0];
-		if(isTypeRegistered(type)) {
-			for(int slotToCheck = 0; slotToCheck < slotLimit; slotToCheck++) {
-				if(assignedSlots[slotToCheck].equals(type)) {
-					slotIndexes = Arrays.copyOf(slotIndexes, slotIndexes.length + 1);
-					slotIndexes[slotIndexes.length - 1] = slotToCheck;
-				}
-			}
-		}
-		return slotIndexes;
-	}
+    /**
+     * Returns an array of slot indexes that have the specified type assigned.
+     * Do not treat results from this as final until postinit or later.
+     *
+     * @param type The type of slot being checked.
+     *
+     * @return an array of slot indexes with the specified type.
+     */
+    public static int[] getIndexesOfAssignedSlotsOfType(String type) {
+        int[] slotIndexes = new int[0];
+        if (!isTypeRegistered(type)) {
+            return slotIndexes;
+        }
+        for (int slotToCheck = 0; slotToCheck < assignedSlots.size(); slotToCheck++) {
+            if (assignedSlots.get(slotToCheck).equals(type)) {
+                slotIndexes = Arrays.copyOf(slotIndexes, slotIndexes.length + 1);
+                slotIndexes[slotIndexes.length - 1] = slotToCheck;
+            }
+        }
+        return slotIndexes;
+    }
 
-	/**
-	 * Returns if the type is registered or not.
-	 *
-	 * @param type The type to check the registration of.
-	 *
-	 * @return If the type is registered or not.
-	 */
-	public static boolean isTypeRegistered(String type) {
-		return registeredTypes.contains(type);
-	}
+    /**
+     * Returns if the type is registered or not.
+     *
+     * @param type The type to check the registration of.
+     *
+     * @return If the type is registered or not.
+     */
+    public static boolean isTypeRegistered(String type) {
+        return registeredTypes.contains(type);
+    }
 
-	/**
-	 * Returns the number of bauble slots that are currently used.
-	 *
-	 * @return The number of bauble slots currently used.
-	 */
-	public static int slotsCurrentlyUsed() {
-		return BaublesConfig.showUnusedSlots ? BaubleExpandedSlots.slotLimit : slotLimit - newSlotsRemaining;
-	}
+    /**
+     * Returns the number of bauble slots that are currently used.
+     *
+     * @return The number of bauble slots currently used.
+     */
+    public static int slotsCurrentlyUsed() {
+        return assignedSlots.size();
+    }
 
-	/**
-	 * Returns the number of bauble slots that are currently unused.
-	 *
-	 * @return The number of bauble slots currently unused.
-	 */
-	public static int slotsCurrentlyUnused() {
-		return newSlotsRemaining;
-	}
+    /**
+     * We now have infinite slots, so this method has been deprecated.
+     *
+     * @return The number of bauble slots currently unused.
+     */
+    @Deprecated
+    public static int slotsCurrentlyUnused() {
+        return 0;
+    }
 
-	/**
-	 * Returns the type of the specified slot, "unknown" if out of range.
-	 *
-	 * @param slot The slot to check
-	 * @return The type of the specified slot or unknown.
-	 */
-	public static String getSlotType(int slot) {
-		if (slot >= 0 & slot < slotLimit) {
-			return assignedSlots[slot];
-		} else {
-			return unknownType;
-		}
-	}
+    /**
+     * Returns the type of the specified slot, "unknown" if out of range.
+     *
+     * @param slot The slot to check
+     * @return The type of the specified slot or unknown.
+     */
+    public static String getSlotType(int slot) {
+        if (slot >= 0 && slot < assignedSlots.size()) {
+            return assignedSlots.get(slot);
+        } else {
+            return unknownType;
+        }
+    }
 
-	/**
-	 * Returns the index of a certain type in the registeredType array
-	 * or -1 if it cannot be found.
-	 *
-	 * @param type The type to get the index of
-	 * @return Index of a type or negative one
-	 */
-	public static int getIndexOfTypeInRegisteredTypes(String type) {
-		return registeredTypes.indexOf(type);
-	}
+    /**
+     * Returns the index of a certain type in the registeredType array
+     * or -1 if it cannot be found.
+     *
+     * @param type The type to get the index of
+     * @return Index of a type or negative one
+     */
+    public static int getIndexOfTypeInRegisteredTypes(String type) {
+        return registeredTypes.indexOf(type);
+    }
 
-	/**
-	 * Returns the currently registered bauble types.
-	 * If pre-initialization is done this list is effectively final.
-	 *
-	 * @return The currently registered bauble types.
-	 */
-	public static ArrayList<String> getCurrentlyRegisteredTypes() {
-		return registeredTypes;
-	}
+    /**
+     * Returns the currently registered bauble types.
+     * If pre-initialization is done this list is effectively final.
+     *
+     * @return The currently registered bauble types.
+     */
+    public static ArrayList<String> getCurrentlyRegisteredTypes() {
+        return registeredTypes;
+    }
 
-	/**
-	 * Returns the current slot assignments as a string array.
-	 * If initialization is done this list is effectively final.
-	 *
-	 * @return The current contents of the slots array.
-	 */
-	public static String[] getCurrentSlotAssignments() {
-		return assignedSlots;
-	}
+    /**
+     * Returns the current slot assignments as a string array.
+     * If initialization is done this list is effectively final.
+     *
+     * @return The current contents of the slots array.
+     */
+    public static String[] getCurrentSlotAssignments() {
+        return assignedSlots.toArray(new String[]{});
+    }
 
-	/**
-	 * Returns a type based on the specified BaubleType.
-	 *
-	 * @param type The BaubleType to get a matching type from.
-	 *
-	 * @return The type matching the BaubleType or unknown.
-	 */
-	public static String getTypeFromBaubleType(BaubleType type) {
-		if(type == null) {
-			return invalidType;
-		}
+    /**
+     * Returns a type based on the specified BaubleType.
+     *
+     * @param type The BaubleType to get a matching type from.
+     *
+     * @return The type matching the BaubleType or unknown.
+     */
+    public static String getTypeFromBaubleType(BaubleType type) {
+        if (type == null) {
+            return invalidType;
+        }
         return switch (type) {
             case RING -> ringType;
             case AMULET -> amuletType;
             case BELT -> beltType;
             case UNIVERSAL -> universalType;
-            default -> unknownType;
         };
-	}
+    }
 
-	/**
-	 * This is only intended to be used by the Baubles manualSlotSelection config option, if it is enabled.
-	 * Overrides assigned slots with the contents of a string array.
-	 * Any entry that would go over slotLimit is ignored.
-	 * If an array is shorter than slotLimit all remaining slots are set to unknown.
-	 * Invalid slot types are set to unknown.
-	 *
-	 * @param overrideSlots The array to override assigned slots with.
-	 */
-	public static void overrideSlots(String[] overrideSlots) {
-		if(Loader.instance().getLoaderState() == LoaderState.INITIALIZATION) {
-			newSlotsRemaining = 0;
-			for(int slot = 0; slot < slotLimit; slot++) {
-				if(slot < overrideSlots.length && isTypeRegistered(overrideSlots[slot]) && !overrideSlots[slot].equals(unknownType)) {
-					assignedSlots[slot] = overrideSlots[slot];
-				} else {
-					assignedSlots[slot] = unknownType;
-					newSlotsRemaining++;
-				}
-			}
-		}
-	}
+    /**
+     * This is only intended to be used by the Baubles manualSlotSelection config option, if it is enabled.
+     * Overrides assigned slots with the contents of a string array.
+     * Any entry that would go over slotLimit is ignored.
+     * If an array is shorter than slotLimit all remaining slots are set to unknown.
+     * Invalid slot types are set to unknown.
+     *
+     * @param overrideSlots The array to override assigned slots with.
+     */
+    public static void overrideSlots(String[] overrideSlots) {
+        if (Loader.instance().getLoaderState() != LoaderState.INITIALIZATION) {
+            return;
+        }
+        assignedSlots.clear();
+        for (String overrideSlot : overrideSlots) {
+            if (isTypeRegistered(overrideSlot) && !overrideSlot.equals(unknownType)) {
+                assignedSlots.add(overrideSlot);
+            } else {
+                assignedSlots.add(unknownType);
+            }
+        }
+    }
 
-	private static int newSlotsRemaining;
-	private static final String[] assignedSlots = new String[slotLimit];
-	private static final ArrayList<String> registeredTypes = new ArrayList<String>();
-	static {
-		registeredTypes.add(unknownType);
-		registeredTypes.add(ringType);
-		registeredTypes.add(amuletType);
-		registeredTypes.add(beltType);
+    private static final ArrayList<String> assignedSlots = new ArrayList<>();
+    private static final ArrayList<String> registeredTypes = new ArrayList<>();
+    static {
+        registeredTypes.add(unknownType);
+        registeredTypes.add(ringType);
+        registeredTypes.add(amuletType);
+        registeredTypes.add(beltType);
         registeredTypes.add(universalType);
-		registeredTypes.add(headType);
-		registeredTypes.add(bodyType);
-		registeredTypes.add(charmType);
-		registeredTypes.add(capeType);
-		registeredTypes.add(shieldType);
-		registeredTypes.add(quiverType);
-		registeredTypes.add(gauntletType);
-		registeredTypes.add(earringType);
-		registeredTypes.add(wingsType);
+        registeredTypes.add(headType);
+        registeredTypes.add(bodyType);
+        registeredTypes.add(charmType);
+        registeredTypes.add(capeType);
+        registeredTypes.add(shieldType);
+        registeredTypes.add(quiverType);
+        registeredTypes.add(gauntletType);
+        registeredTypes.add(earringType);
+        registeredTypes.add(wingsType);
 
-		assignedSlots[0] = amuletType;
-		assignedSlots[1] = ringType;
-		assignedSlots[2] = ringType;
-		assignedSlots[3] = beltType;
-		newSlotsRemaining = slotLimit - 4;
-		for(int slot = 4; slot < slotLimit; slot++) {
-			assignedSlots[slot] = unknownType;
-		}
-	}
+        assignedSlots.add(amuletType);
+        assignedSlots.add(ringType);
+        assignedSlots.add(ringType);
+        assignedSlots.add(beltType);
+    }
 
 }

--- a/src/main/java/baubles/client/gui/GuiPlayerExpanded.java
+++ b/src/main/java/baubles/client/gui/GuiPlayerExpanded.java
@@ -188,7 +188,7 @@ public class GuiPlayerExpanded extends GuiContainer implements INEIGuiHandler {
 
         // Bauble slot backgrounds
         this.mc.getTextureManager().bindTexture(useOldGuiRendering ? background : gui_background);
-        for (int slotIndex = 0; slotIndex < BaubleExpandedSlots.slotLimit; slotIndex++) {
+        for (int slotIndex = 0; slotIndex < BaubleExpandedSlots.slotsCurrentlyUsed(); slotIndex++) {
             String slotType = BaubleExpandedSlots.getSlotType(slotIndex);
             if (!BaublesConfig.showUnusedSlots && slotType.equals(BaubleExpandedSlots.unknownType)) {
                 continue;

--- a/src/main/java/baubles/common/BaublesConfig.java
+++ b/src/main/java/baubles/common/BaublesConfig.java
@@ -46,7 +46,7 @@ public class BaublesConfig {
 
         //categoryClient
         useOldGuiButton = config.getBoolean("useOldGuiButton", categoryClient, useOldGuiButton, "Use the old Baubles Button texture and location instead.\n");
-        useOldGuiRendering = config.getBoolean("useOldRendering", categoryClient, useOldGuiRendering, "Display the old Bauble GUI instead of the new sidebar.\nUsing over 20 slots in old rendering is not supported.\n");
+        useOldGuiRendering = config.getBoolean("useOldRendering", categoryClient, useOldGuiRendering, "Display the old Bauble GUI instead of the new sidebar.\nUsing old rendering with more than 20 slots works, but results in visual oddities and is not supported.\n");
         maxColumns = config.getInt("maxColumns", categoryClient, 4, 1, Integer.MAX_VALUE, "Maximum number of columns shown in the baubles inventory.\n"
         );
 

--- a/src/main/java/baubles/common/BaublesConfig.java
+++ b/src/main/java/baubles/common/BaublesConfig.java
@@ -66,10 +66,9 @@ public class BaublesConfig {
         config.getCategory(categoryOverride).get("defualtSlotTypes").set(currentSlotAssignments);
 
         overrideSlotTypes = config.getStringList("slotTypeOverrides", categoryOverride, overrideSlotTypes,
-            "Slot assignments to use if manualSlotSelection is enabled.\nAny assignments after the first " +
-            BaubleExpandedSlots.slotLimit + " will be ignored.\n!Adding, moving, or removing slots of the "
-            + BaubleExpandedSlots.amuletType + ", " + BaubleExpandedSlots.ringType + ", or " + BaubleExpandedSlots.beltType +
-            " types will reduce compatibility with mods made for original Baubles versions!\n",
+            "Slot assignments to use if manualSlotSelection is enabled.\n!Adding, moving, or removing slots of the "
+                + BaubleExpandedSlots.amuletType + ", " + BaubleExpandedSlots.ringType + ", or " + BaubleExpandedSlots.beltType +
+                " types will reduce compatibility with mods made for original Baubles versions!\n",
             currentlyRegisteredTypes.toArray(new String[0])
         );
 

--- a/src/main/java/baubles/common/BaublesConfig.java
+++ b/src/main/java/baubles/common/BaublesConfig.java
@@ -47,7 +47,7 @@ public class BaublesConfig {
         //categoryClient
         useOldGuiButton = config.getBoolean("useOldGuiButton", categoryClient, useOldGuiButton, "Use the old Baubles Button texture and location instead.\n");
         useOldGuiRendering = config.getBoolean("useOldRendering", categoryClient, useOldGuiRendering, "Display the old Bauble GUI instead of the new sidebar.\nUsing over 20 slots in old rendering is not supported.\n");
-        maxColumns = config.getInt("maxColumns", categoryClient, 4, 1, 5, "Maximum number of columns shown in the baubles inventory (1-5).\n"
+        maxColumns = config.getInt("maxColumns", categoryClient, 4, 1, Integer.MAX_VALUE, "Maximum number of columns shown in the baubles inventory.\n"
         );
 
         //categoryMenu

--- a/src/main/java/baubles/common/container/ContainerPlayerExpanded.java
+++ b/src/main/java/baubles/common/container/ContainerPlayerExpanded.java
@@ -83,12 +83,12 @@ public class ContainerPlayerExpanded extends Container {
 
         // Bauble slots
         baubleFirstSlotIndex = slotsAdded;
-        for (i = 0; i < BaubleExpandedSlots.slotLimit; i++) {
-            String slotType = BaubleExpandedSlots.getSlotType(i);
+        String[] currentSlotAssignments = BaubleExpandedSlots.getCurrentSlotAssignments();
+        for (String slotType: currentSlotAssignments) {
             if (BaublesConfig.showUnusedSlots || !slotType.equals(BaubleExpandedSlots.unknownType)) {
                 Slot slot = useOldGuiRendering
-                    ? new SlotBauble(baubles, slotType, i, slotStartX + (slotOffset * (i / 4)), slotStartY + (slotOffset * (i % 4)))
-                    : new SlotBauble(baubles, slotType, i, -18 - (18 * (i % getColumns())), 12 + (slotOffset * (i / getColumns())));
+                    ? new SlotBauble(baubles, slotType, baubleSlotCount, slotStartX + (slotOffset * (baubleSlotCount / 4)), slotStartY + (slotOffset * (baubleSlotCount % 4)))
+                    : new SlotBauble(baubles, slotType, baubleSlotCount, -18 - (18 * (baubleSlotCount % getColumns())), 12 + (slotOffset * (baubleSlotCount / getColumns())));
                 addSlotToContainer(slot);
                 baubleSlotCount++;
             }
@@ -172,7 +172,7 @@ public class ContainerPlayerExpanded extends Container {
             slotRowOffset = 0;
         }
 
-        for (int i = 0; i < activeBaubleSlots && i < BaubleExpandedSlots.slotLimit; i++) {
+        for (int i = 0; i < activeBaubleSlots && i < BaubleExpandedSlots.slotsCurrentlyUsed(); i++) {
             Slot slot = (Slot) this.inventorySlots.get(baubleFirstSlotIndex + i);
             int row = i / columns;
             int scrolledRow = row - slotRowOffset;

--- a/src/main/java/baubles/common/container/InventoryBaubles.java
+++ b/src/main/java/baubles/common/container/InventoryBaubles.java
@@ -23,285 +23,285 @@ import net.minecraft.nbt.NBTTagList;
 import net.minecraft.util.MathHelper;
 
 public class InventoryBaubles implements IInventory {
-	public ItemStack[] stackList;
-	private Container eventHandler;
-	public WeakReference<EntityPlayer> player;
-	public boolean blockEvents=false;
+    public ItemStack[] stackList;
+    private Container eventHandler;
+    public WeakReference<EntityPlayer> player;
+    public boolean blockEvents=false;
 
-	public InventoryBaubles(EntityPlayer player) {
-		stackList = new ItemStack[BaubleExpandedSlots.slotLimit];
-		this.player = new WeakReference<>(player);
-	}
+    public InventoryBaubles(EntityPlayer player) {
+        stackList = new ItemStack[BaubleExpandedSlots.slotsCurrentlyUsed()];
+        this.player = new WeakReference<>(player);
+    }
 
-	public Container getEventHandler() {
-		return eventHandler;
-	}
+    public Container getEventHandler() {
+        return eventHandler;
+    }
 
-	public void setEventHandler(Container eventHandler) {
-		this.eventHandler = eventHandler;
-	}
+    public void setEventHandler(Container eventHandler) {
+        this.eventHandler = eventHandler;
+    }
 
-	/**
-	 * Returns the number of slots in the inventory.
-	 */
-	@Override
-	public int getSizeInventory() {
-		return stackList.length;
-	}
+    /**
+     * Returns the number of slots in the inventory.
+     */
+    @Override
+    public int getSizeInventory() {
+        return stackList.length;
+    }
 
-	/**
-	 * Returns the stack in slot i
-	 */
-	@Override
-	public ItemStack getStackInSlot(int slot) {
-		return slot >= getSizeInventory() ? null : stackList[slot];
-	}
+    /**
+     * Returns the stack in slot i
+     */
+    @Override
+    public ItemStack getStackInSlot(int slot) {
+        return slot >= getSizeInventory() ? null : stackList[slot];
+    }
 
-	/**
-	 * Returns the name of the inventory
-	 */
-	@Override
-	public String getInventoryName() {
-		return "";
-	}
+    /**
+     * Returns the name of the inventory
+     */
+    @Override
+    public String getInventoryName() {
+        return "";
+    }
 
-	/**
-	 * Returns if the inventory is named
-	 */
-	@Override
-	public boolean hasCustomInventoryName() {
-		return false;
-	}
+    /**
+     * Returns if the inventory is named
+     */
+    @Override
+    public boolean hasCustomInventoryName() {
+        return false;
+    }
 
-	/**
-	 * When some containers are closed they call this on each slot, then drop
-	 * whatever it returns as an EntityItem - like when you close a workbench
-	 * GUI.
-	 */
-	@Override
-	public ItemStack getStackInSlotOnClosing(int slot) {
-		if(stackList[slot] != null) {
-			ItemStack itemstack = this.stackList[slot];
-			stackList[slot] = null;
-			return itemstack;
-		} else {
-			return null;
-		}
-	}
+    /**
+     * When some containers are closed they call this on each slot, then drop
+     * whatever it returns as an EntityItem - like when you close a workbench
+     * GUI.
+     */
+    @Override
+    public ItemStack getStackInSlotOnClosing(int slot) {
+        if(stackList[slot] != null) {
+            ItemStack itemstack = this.stackList[slot];
+            stackList[slot] = null;
+            return itemstack;
+        } else {
+            return null;
+        }
+    }
 
-	/**
-	 * Removes from an inventory slot (first arg) up to a specified number
-	 * (second arg) of items and returns them in a new stack.
-	 */
-	@Override
-	public ItemStack decrStackSize(int slot, int decrementBy) {
-		if(stackList[slot] != null) {
-			ItemStack itemstack;
+    /**
+     * Removes from an inventory slot (first arg) up to a specified number
+     * (second arg) of items and returns them in a new stack.
+     */
+    @Override
+    public ItemStack decrStackSize(int slot, int decrementBy) {
+        if(stackList[slot] != null) {
+            ItemStack itemstack;
 
-			if(stackList[slot].stackSize <= decrementBy) {
-				itemstack = stackList[slot];
+            if(stackList[slot].stackSize <= decrementBy) {
+                itemstack = stackList[slot];
 
-				if(itemstack != null && itemstack.getItem() instanceof IBauble) {
-					((IBauble) itemstack.getItem()).onUnequipped(itemstack, player.get());
-				}
+                if(itemstack != null && itemstack.getItem() instanceof IBauble) {
+                    ((IBauble) itemstack.getItem()).onUnequipped(itemstack, player.get());
+                }
 
-				stackList[slot] = null;
-			} else {
-				itemstack = stackList[slot].splitStack(decrementBy);
+                stackList[slot] = null;
+            } else {
+                itemstack = stackList[slot].splitStack(decrementBy);
 
-				if(itemstack != null && itemstack.getItem() instanceof IBauble) {
-					((IBauble)itemstack.getItem()).onUnequipped(itemstack, player.get());
-				}
+                if(itemstack != null && itemstack.getItem() instanceof IBauble) {
+                    ((IBauble)itemstack.getItem()).onUnequipped(itemstack, player.get());
+                }
 
-				if(stackList[slot].stackSize == 0) {
-					stackList[slot] = null;
-				}
-			}
+                if(stackList[slot].stackSize == 0) {
+                    stackList[slot] = null;
+                }
+            }
 
-			if(eventHandler != null)
-				eventHandler.onCraftMatrixChanged(this);
-			syncSlotToClients(slot);
-			return itemstack;
-		} else {
-			return null;
-		}
-	}
+            if(eventHandler != null)
+                eventHandler.onCraftMatrixChanged(this);
+            syncSlotToClients(slot);
+            return itemstack;
+        } else {
+            return null;
+        }
+    }
 
-	/**
-	 * Sets the given item stack to the specified slot in the inventory (can be
-	 * crafting or armor sections).
-	 */
-	@Override
-	public void setInventorySlotContents(int slot, ItemStack stack) {
-		if(!blockEvents && stackList[slot] != null) {
-        	((IBauble)stackList[slot].getItem()).onUnequipped(stackList[slot], player.get());
-		}
-		stackList[slot] = stack;
-		if(!blockEvents && stack != null && stack.getItem() instanceof IBauble) {
-			if(player.get()!=null) {
-				((IBauble) stack.getItem()).onEquipped(stack, player.get());
-			}
-		}
-		if(eventHandler != null) {
-			eventHandler.onCraftMatrixChanged(this);
-		}
-		syncSlotToClients(slot);
-	}
+    /**
+     * Sets the given item stack to the specified slot in the inventory (can be
+     * crafting or armor sections).
+     */
+    @Override
+    public void setInventorySlotContents(int slot, ItemStack stack) {
+        if(!blockEvents && stackList[slot] != null) {
+            ((IBauble)stackList[slot].getItem()).onUnequipped(stackList[slot], player.get());
+        }
+        stackList[slot] = stack;
+        if(!blockEvents && stack != null && stack.getItem() instanceof IBauble) {
+            if(player.get()!=null) {
+                ((IBauble) stack.getItem()).onEquipped(stack, player.get());
+            }
+        }
+        if(eventHandler != null) {
+            eventHandler.onCraftMatrixChanged(this);
+        }
+        syncSlotToClients(slot);
+    }
 
-	/**
-	 * Returns the maximum stack size for an inventory slot.
-	 */
-	@Override
-	public int getInventoryStackLimit() {
-		return 1;
-	}
+    /**
+     * Returns the maximum stack size for an inventory slot.
+     */
+    @Override
+    public int getInventoryStackLimit() {
+        return 1;
+    }
 
-	/**
-	 * For tile entities, ensures the chunk containing the tile entity is saved
-	 * to disk later - the game won't think it hasn't changed and skip it.
-	 */
-	@Override
-	public void markDirty() {
-		try {
-			player.get().inventory.markDirty();
-		} catch (Exception ignored) {
-		}
-	}
+    /**
+     * For tile entities, ensures the chunk containing the tile entity is saved
+     * to disk later - the game won't think it hasn't changed and skip it.
+     */
+    @Override
+    public void markDirty() {
+        try {
+            player.get().inventory.markDirty();
+        } catch (Exception ignored) {
+        }
+    }
 
-	/**
-	 * Do not make give this method the name canInteractWith because it clashes
-	 * with Container
-	 */
-	@Override
-	public boolean isUseableByPlayer(EntityPlayer player) {
-		return true;
-	}
+    /**
+     * Do not make give this method the name canInteractWith because it clashes
+     * with Container
+     */
+    @Override
+    public boolean isUseableByPlayer(EntityPlayer player) {
+        return true;
+    }
 
-	@Override
-	public void openInventory() {
-	}
+    @Override
+    public void openInventory() {
+    }
 
-	@Override
-	public void closeInventory() {
-	}
+    @Override
+    public void closeInventory() {
+    }
 
-	/**
-	 * Returns true if automation is allowed to insert the given stack (ignoring
-	 * stack size) into the given slot.
-	 */
-	@Override
-	public boolean isItemValidForSlot(int slot, ItemStack stack) {
-		String slotType = BaubleExpandedSlots.getSlotType(slot);
-		if (stack == null || slotType == null) {
-			return false;
-		}
+    /**
+     * Returns true if automation is allowed to insert the given stack (ignoring
+     * stack size) into the given slot.
+     */
+    @Override
+    public boolean isItemValidForSlot(int slot, ItemStack stack) {
+        String slotType = BaubleExpandedSlots.getSlotType(slot);
+        if (stack == null || slotType == null) {
+            return false;
+        }
 
-		Item item = stack.getItem();
-		if(!(item instanceof IBauble) || !((IBauble) item).canEquip(stack, player.get())) {
-			return false;
-		}
+        Item item = stack.getItem();
+        if(!(item instanceof IBauble) || !((IBauble) item).canEquip(stack, player.get())) {
+            return false;
+        }
 
-		String[] types;
-		if(item instanceof IBaubleExpanded) {
-			types = ((IBaubleExpanded)item).getBaubleTypes(stack);
-		} else {
-			BaubleType legacyType = ((IBauble)item).getBaubleType(stack);
-			types = new String[] {BaubleExpandedSlots.getTypeFromBaubleType(legacyType)};
-		}
+        String[] types;
+        if(item instanceof IBaubleExpanded) {
+            types = ((IBaubleExpanded)item).getBaubleTypes(stack);
+        } else {
+            BaubleType legacyType = ((IBauble)item).getBaubleType(stack);
+            types = new String[] {BaubleExpandedSlots.getTypeFromBaubleType(legacyType)};
+        }
 
-		for(String type : types) {
-			if(type.equals(BaubleExpandedSlots.universalType) || type.equals(slotType)) {
-				return true;
-			}
-		}
+        for(String type : types) {
+            if(type.equals(BaubleExpandedSlots.universalType) || type.equals(slotType)) {
+                return true;
+            }
+        }
 
-		return false;
-	}
+        return false;
+    }
 
-	public void saveNBT(EntityPlayer player) {
-		NBTTagCompound tags = player.getEntityData();
-		saveNBT(tags);
-	}
+    public void saveNBT(EntityPlayer player) {
+        NBTTagCompound tags = player.getEntityData();
+        saveNBT(tags);
+    }
 
-	public void saveNBT(NBTTagCompound tags) {
-		NBTTagList tagList = new NBTTagList();
-		NBTTagCompound invSlot;
-		for (int slot = 0; slot < stackList.length; ++slot) {
-			if (stackList[slot] != null) {
-				invSlot = new NBTTagCompound();
-				invSlot.setByte("Slot", (byte) slot);
-				stackList[slot].writeToNBT(invSlot);
-				tagList.appendTag(invSlot);
-			}
-		}
-		tags.setTag("Baubles.Inventory", tagList);
-	}
+    public void saveNBT(NBTTagCompound tags) {
+        NBTTagList tagList = new NBTTagList();
+        NBTTagCompound invSlot;
+        for (int slot = 0; slot < stackList.length; ++slot) {
+            if (stackList[slot] != null) {
+                invSlot = new NBTTagCompound();
+                invSlot.setByte("Slot", (byte) slot);
+                stackList[slot].writeToNBT(invSlot);
+                tagList.appendTag(invSlot);
+            }
+        }
+        tags.setTag("Baubles.Inventory", tagList);
+    }
 
-	public void readNBT(EntityPlayer player) {
-		NBTTagCompound tags = player.getEntityData();
-		readNBT(tags);
-	}
+    public void readNBT(EntityPlayer player) {
+        NBTTagCompound tags = player.getEntityData();
+        readNBT(tags);
+    }
 
-	public void readNBT(NBTTagCompound tags) {
-		NBTTagList tagList = tags.getTagList("Baubles.Inventory", 10);
-		for (int i = 0; i < tagList.tagCount(); ++i) {
-			NBTTagCompound nbttagcompound = (NBTTagCompound) tagList.getCompoundTagAt(i);
-			int slot = nbttagcompound.getByte("Slot") & 255;
-			ItemStack itemstack = ItemStack.loadItemStackFromNBT(nbttagcompound);
-			if (itemstack != null) {
-				stackList[slot] = itemstack;
-			}
-		}
-	}
+    public void readNBT(NBTTagCompound tags) {
+        NBTTagList tagList = tags.getTagList("Baubles.Inventory", 10);
+        for (int i = 0; i < tagList.tagCount(); ++i) {
+            NBTTagCompound nbttagcompound = (NBTTagCompound) tagList.getCompoundTagAt(i);
+            int slot = nbttagcompound.getByte("Slot") & 255;
+            ItemStack itemstack = ItemStack.loadItemStackFromNBT(nbttagcompound);
+            if (itemstack != null) {
+                stackList[slot] = itemstack;
+            }
+        }
+    }
 
-	public void dropItems(ArrayList<EntityItem> drops) {
-		for (int slot = 0; slot < stackList.length; ++slot) {
-			if (stackList[slot] != null) {
-				EntityItem item = new EntityItem(player.get().worldObj,
-						player.get().posX,
-						player.get().posY + player.get().eyeHeight, player.get().posZ,
-						stackList[slot].copy());
-				item.delayBeforeCanPickup = 40;
-				float f1 = player.get().worldObj.rand.nextFloat() * 0.5F;
-				float f2 = player.get().worldObj.rand.nextFloat() * (float) Math.PI * 2.0F;
-				item.motionX = (-MathHelper.sin(f2) * f1);
-				item.motionZ = (MathHelper.cos(f2) * f1);
-				item.motionY = 0.20000000298023224D;
-				drops.add(item);
-				stackList[slot] = null;
-				syncSlotToClients(slot);
-			}
-		}
-	}
+    public void dropItems(ArrayList<EntityItem> drops) {
+        for (int slot = 0; slot < stackList.length; ++slot) {
+            if (stackList[slot] != null) {
+                EntityItem item = new EntityItem(player.get().worldObj,
+                    player.get().posX,
+                    player.get().posY + player.get().eyeHeight, player.get().posZ,
+                    stackList[slot].copy());
+                item.delayBeforeCanPickup = 40;
+                float f1 = player.get().worldObj.rand.nextFloat() * 0.5F;
+                float f2 = player.get().worldObj.rand.nextFloat() * (float) Math.PI * 2.0F;
+                item.motionX = (-MathHelper.sin(f2) * f1);
+                item.motionZ = (MathHelper.cos(f2) * f1);
+                item.motionY = 0.20000000298023224D;
+                drops.add(item);
+                stackList[slot] = null;
+                syncSlotToClients(slot);
+            }
+        }
+    }
 
-	public void dropItemsAt(ArrayList<EntityItem> drops, Entity entity) {
-		for (int slot = 0; slot < stackList.length; ++slot) {
-			if (stackList[slot] != null && !ItemStackHelper.isSoulBound(stackList[slot])) {
-				EntityItem item = new EntityItem(entity.worldObj,
-						entity.posX, entity.posY + entity.getEyeHeight(), entity.posZ,
-						stackList[slot].copy());
-				item.delayBeforeCanPickup = 40;
-				float f1 = entity.worldObj.rand.nextFloat() * 0.5F;
-				float f2 = entity.worldObj.rand.nextFloat() * (float) Math.PI * 2.0F;
-				item.motionX = (-MathHelper.sin(f2) * f1);
-				item.motionZ = (MathHelper.cos(f2) * f1);
-				item.motionY = 0.20000000298023224D;
-				drops.add(item);
-				stackList[slot] = null;
-				syncSlotToClients(slot);
-			}
-		}
-	}
+    public void dropItemsAt(ArrayList<EntityItem> drops, Entity entity) {
+        for (int slot = 0; slot < stackList.length; ++slot) {
+            if (stackList[slot] != null && !ItemStackHelper.isSoulBound(stackList[slot])) {
+                EntityItem item = new EntityItem(entity.worldObj,
+                    entity.posX, entity.posY + entity.getEyeHeight(), entity.posZ,
+                    stackList[slot].copy());
+                item.delayBeforeCanPickup = 40;
+                float f1 = entity.worldObj.rand.nextFloat() * 0.5F;
+                float f2 = entity.worldObj.rand.nextFloat() * (float) Math.PI * 2.0F;
+                item.motionX = (-MathHelper.sin(f2) * f1);
+                item.motionZ = (MathHelper.cos(f2) * f1);
+                item.motionY = 0.20000000298023224D;
+                drops.add(item);
+                stackList[slot] = null;
+                syncSlotToClients(slot);
+            }
+        }
+    }
 
-	public void syncSlotToClients(int slot) {
-		try {
-			EntityPlayer entityPlayer = player.get();
-			if (entityPlayer != null && !entityPlayer.worldObj.isRemote) {
-				PacketHandler.INSTANCE.sendToAll(new PacketSyncBauble(player.get(), slot));
-			}
-		} catch (Exception e) {
-			e.printStackTrace();
-		}
-	}
+    public void syncSlotToClients(int slot) {
+        try {
+            EntityPlayer entityPlayer = player.get();
+            if (entityPlayer != null && !entityPlayer.worldObj.isRemote) {
+                PacketHandler.INSTANCE.sendToAll(new PacketSyncBauble(player.get(), slot));
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
 
 }


### PR DESCRIPTION
Allow for infinite bauble slots to be set. Old rendering functions with 21+ slots, but looks weird, so the config comment has a warning.
<img width="2560" height="1414" alt="old" src="https://github.com/user-attachments/assets/5d325d1b-ec23-4bd3-ae4e-7ac0a93d9c11" />
<img width="2560" height="1414" alt="newtop" src="https://github.com/user-attachments/assets/6155dd8a-5f57-43c1-a964-c0616b0f1c09" />
<img width="2560" height="1414" alt="newbottom" src="https://github.com/user-attachments/assets/ec9891c2-7c47-4fe1-92a8-5099853c645a" />

[slotLimit doesn't seem to be used in any mods](https://github.com/search?q=org%3AGTNewHorizons+Baubles+slotLimit&type=code) so it was removed. newSlotsRemaining was private so it should also cause no problems by being removed.

Also allow for the column config to be any positive number, default is unchanged from 4 (above screenshots are 7)